### PR TITLE
ci: remove Maven plugin from release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -19,7 +19,6 @@ verifyConditions:
   - '@semantic-release/git'
   - '@semantic-release/github'
   - '@semantic-release/changelog'
-  - 'semantic-release-maven'
 
 analyzeCommits:
   - path: "@semantic-release/commit-analyzer"


### PR DESCRIPTION
# Description

We do not have a Maven project. So this module is not needed and will fail due to missing `pom.xml`.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
