### PR TITLE
ci: no special checks for feature branches with one commit

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -56,7 +56,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Related to `validateSingleCommit` you can opt-in to validate that the PR
           # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true
+          validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
# Description

There is no longer the need to enforce that the commit title in a feature branch must match the PR title in case there is one commit only. The project has been configured to always use the PR title and description as commit message for the squashed commit.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
