### PR TITLE
chore: relocate service classes

### DIFF
--- a/src/adapter/UnitOfWork.ts
+++ b/src/adapter/UnitOfWork.ts
@@ -1,7 +1,7 @@
 import { SyncCalendarApplicationService as SyncCalendarApplicationService } from "../application/SyncCalendarApplicationService";
 import { AppointmentParserService } from "../domain/service/AppointmentParserService";
 import { Configuration } from "./Configuration";
-import { ClickTtCsvFileAppointmentParserServiceImpl } from "./endpoint/service/ClickTtCsvFileAppointmentParserServiceImpl";
+import { ClickTtCsvFileAppointmentParserServiceImpl } from "./service/ClickTtCsvFileAppointmentParserServiceImpl";
 import { Logger } from "./Logger";
 
 export abstract class UnitOfWork {

--- a/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
+++ b/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'; // 'fs/promises' not available in node 12
 import csv from 'csv-parser';
-import { Appointment, AppointmentFactory } from "../../../domain/model/appointment/Appointment";
-import { AppointmentParserService } from "../../../domain/service/AppointmentParserService";
-import { Configuration } from "../../Configuration";
+import { Appointment, AppointmentFactory } from "../../domain/model/appointment/Appointment";
+import { AppointmentParserService } from "../../domain/service/AppointmentParserService";
+import { Configuration } from "../Configuration";
 import { LocalDateTime } from '@js-joda/core';
 
 export class ClickTtCsvFileAppointmentParserServiceImpl implements AppointmentParserService {


### PR DESCRIPTION
# Description

Service implementation classes were located in `endpoints` which is wrong. This PR moves the classes sinto the adapter package.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
