### PR TITLE
fix: use the arguments provided on command line

### DIFF
--- a/src/adapter/endpoint/CommandLineInterface.ts
+++ b/src/adapter/endpoint/CommandLineInterface.ts
@@ -1,22 +1,26 @@
 import "reflect-metadata";
 
-import * as yargs from 'yargs';
 import { SyncCalendarApplicationService } from "../../application/SyncCalendarApplicationService";
 import { SERVICE_IDENTIFIER } from "../../dependency_injection";
 import container from "../container";
 
+import yargs from 'yargs/yargs';
+
 export class CommandLineInterface {
-  main() {
-    const args = yargs.options({
-      'f': {
-        alias: 'file',
+  main(args: string[]) {
+    const parsedArguments = this.extractArguments(args);
+
+    container.get<SyncCalendarApplicationService>(SERVICE_IDENTIFIER.SyncCalendarAppService).syncCalendar(parsedArguments.appointmentFile);
+  }
+
+  private extractArguments(args: string[]) {
+    return yargs(args).options({
+      'appointment-file': {
+        alias: 'f',
         demandOption: true,
         description: 'CSV file with all appointments',
         type: 'string'
       }
-    }).argv;
-
-    // FIXME should read `args.f`
-    container.get<SyncCalendarApplicationService>(SERVICE_IDENTIFIER.SyncCalendarAppService).syncCalendar('/temp/Vereinsspielplan_20220922150454.csv');
+    }).parseSync();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import { CommandLineInterface } from "./adapter/endpoint/CommandLineInterface";
 
 // for simplicity
-new CommandLineInterface().main();
+new CommandLineInterface().main(process.argv);

--- a/tests/adapter/endpoint/CommandLineInterface.spec.ts
+++ b/tests/adapter/endpoint/CommandLineInterface.spec.ts
@@ -1,0 +1,37 @@
+import container from "../../../src/adapter/container";
+
+import { CommandLineInterface } from "../../../src/adapter/endpoint/CommandLineInterface";
+import { SyncCalendarApplicationService } from "../../../src/application/SyncCalendarApplicationService";
+import { SERVICE_IDENTIFIER } from "../../../src/dependency_injection";
+
+describe('CommandLineInterface', () => {
+    it('should accept -f parameter', () => {
+        // give
+        const givenArguments = ["-f", "xxx.csv"];
+
+        const spy = jest.spyOn(container.get<SyncCalendarApplicationService>(SERVICE_IDENTIFIER.SyncCalendarAppService), 'syncCalendar');
+        spy.mockImplementation();
+
+        // when
+        new CommandLineInterface().main(givenArguments);
+
+        // then
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toBe("xxx.csv");
+    });
+
+    it('should accept --appointment-file parameter', () => {
+        // given
+        const givenArguments = ["--appointment-file", "xxx.csv"];
+
+        const spy = jest.spyOn(container.get<SyncCalendarApplicationService>(SERVICE_IDENTIFIER.SyncCalendarAppService), 'syncCalendar');
+        spy.mockImplementation();
+
+        // when
+        new CommandLineInterface().main(givenArguments);
+
+        // then
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toBe("xxx.csv");
+    });
+});


### PR DESCRIPTION
# Description

So far we used hardcoded values for the command line parameters instead of the real value. This PR fixes this problem.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
