### PR TITLE
chore: create internal appointments with title and start date time

### DIFF
--- a/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
+++ b/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
@@ -18,7 +18,7 @@ export class ClickTtCsvFileAppointmentParserServiceImpl implements AppointmentPa
             Readable.from(this.fileStorageService.readFile(`${filename}`))
                 .pipe(csv({ separator: ';' }))
                 .on('data', (data) => {
-                    appointments.add(AppointmentFactory.createFromClickTTCsv(data));
+                    appointments.add(AppointmentFactory.create(data.HeimVereinName, data.GastVereinName, data.Termin));
                 })
                 .on('end', () => {
                     this.logger.info("Found " + appointments.size + " appointments in CSV file.");

--- a/src/application/SyncCalendarApplicationService.ts
+++ b/src/application/SyncCalendarApplicationService.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "inversify";
 import { SERVICE_IDENTIFIER } from "../dependency_injection";
+import { Appointment } from "../domain/model/appointment/Appointment";
 import { AppointmentParserService } from "../domain/service/AppointmentParserService";
 
 @injectable()
@@ -8,9 +9,7 @@ export class SyncCalendarApplicationService {
 
     async syncCalendar(appointmentFilename: string) {
         // parsing ClickTT CSV file
-       this.appointmentParserService.parseAppointments(appointmentFilename);
-       
-        // download Calendar Items
+       const appointments: Set<Appointment> = await this.appointmentParserService.parseAppointments(appointmentFilename);
 
         // for each calendar item --> check against Click-TT appointment and do the action
 

--- a/src/domain/model/appointment/Appointment.ts
+++ b/src/domain/model/appointment/Appointment.ts
@@ -8,6 +8,6 @@ export class AppointmentFactory {
     static create(localTeam: string, foreignTeam: string, startDateTime: string): Appointment {
         const formatter = DateTimeFormatter.ofPattern('dd.MM.yyyy HH:mm');
 
-        return new Appointment("${localTeam} - ${foreignTeam}", LocalDateTime.parse(startDateTime, formatter));
+        return new Appointment(localTeam + " - " + foreignTeam, LocalDateTime.parse(startDateTime, formatter));
     }
 }

--- a/src/domain/model/appointment/Appointment.ts
+++ b/src/domain/model/appointment/Appointment.ts
@@ -1,11 +1,13 @@
-import {LocalDateTime} from '@js-joda/core';
+import {DateTimeFormatter, LocalDateTime} from '@js-joda/core';
 
 export class Appointment {
-    constructor(readonly title: String, readonly description: String, readonly gameCount: Number, readonly localTeamName: String, readonly foreignTeamName: String, readonly startDateTime: LocalDateTime) {}
+    constructor(readonly title: string, readonly startDateTime: LocalDateTime) {}
 }
 
 export class AppointmentFactory {
-    static createFromClickTTCsv(data: any): Appointment {
-        return new Appointment('title', 'description', 4, 'localTeam', 'foreignTeam', LocalDateTime.of(2022, 1, 1));
+    static create(localTeam: string, foreignTeam: string, startDateTime: string): Appointment {
+        const formatter = DateTimeFormatter.ofPattern('dd.MM.yyyy HH:mm');
+
+        return new Appointment("${localTeam} - ${foreignTeam}", LocalDateTime.parse(startDateTime, formatter));
     }
 }

--- a/tests/domain/model/appointment/Appointment.spec.ts
+++ b/tests/domain/model/appointment/Appointment.spec.ts
@@ -1,6 +1,6 @@
 import {Appointment, AppointmentFactory} from "../../../../src/domain/model/appointment/Appointment";
 
-describe('Create Appointment Factory', () => {
+describe('Appointment Factory', () => {
     it('should have a title equal to "local - foreign" team name', () => {
         // when
         const actualAppointment: Appointment = AppointmentFactory.create('local', 'remote', '01.01.1970 00:00');
@@ -14,6 +14,6 @@ describe('Create Appointment Factory', () => {
         const actualAppointment: Appointment = AppointmentFactory.create('local', 'remote', '01.01.1970 00:00');
 
         // then
-        expect(actualAppointment.startDateTime.toEpochSecond).toEqual(7);
+        expect(actualAppointment.startDateTime.toString()).toEqual('1970-01-01T00:00');
     })
 })

--- a/tests/domain/model/appointment/Appointment.ts
+++ b/tests/domain/model/appointment/Appointment.ts
@@ -1,0 +1,19 @@
+import {Appointment, AppointmentFactory} from "../../../../src/domain/model/appointment/Appointment";
+
+describe('Create Appointment Factory', () => {
+    it('should have a title equal to "local - foreign" team name', () => {
+        // when
+        const actualAppointment: Appointment = AppointmentFactory.create('local', 'remote', '01.01.1970 00:00');
+
+        // then
+        expect(actualAppointment.title).toEqual("local - remote");
+    })
+
+    it('should parse the start date time', () => {
+        // when
+        const actualAppointment: Appointment = AppointmentFactory.create('local', 'remote', '01.01.1970 00:00');
+
+        // then
+        expect(actualAppointment.startDateTime.toEpochSecond).toEqual(7);
+    })
+})

--- a/tests/dummy.spec.ts
+++ b/tests/dummy.spec.ts
@@ -1,5 +1,0 @@
-describe("Dummy", () => {
-  it("just do it", () => {
-    expect(true).toBeTruthy();
-  });
-});


### PR DESCRIPTION
# Description

Creates the internal model based on the appointment CSV file. "Title" shows the local and foreign team name. The appointment date and time are taken from the CSV file.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
