### PR TITLE
fix: do not show address if empty

### DIFF
--- a/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
+++ b/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
@@ -70,7 +70,7 @@ export class ClickTtCsvFileAppointmentParserServiceImpl implements AppointmentPa
                     const startDateTime = LocalDateTime.parse(data.Termin, csvDateTimeFormatter)
 
                     if (data.GastVereinName != 'spielfrei') {
-                        const location = data.HalleName + ", " + data.HalleStrasse + ", " + data.HallePLZ + " " + data.HalleOrt;
+                        const location = data.HalleName || data.HalleStrasse || data.HallePLZ || data.HalleOrt ? data.HalleName + ", " + data.HalleStrasse + ", " + data.HallePLZ + " " + data.HalleOrt : '';
                         const isCup = data.Runde == 'Pokal'
 
                         appointments.add(AppointmentFactory.createFromCsv(data.HeimMannschaft, data.GastMannschaft, startDateTime, data.Staffel, data.BegegnungNr, location, data.Altersklasse, isCup, data.Runde));

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -6,8 +6,7 @@ import { FileStorageService } from "../../../src/domain/service/FileStorageServi
 
 const defaultAppointments = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse
 10.10.2022 11:45;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren
-11.10.2022 11:45;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;spielfrei;;2;Herren
-12.10.2022 11:45;3. KK West;VR;VfL Hamburg;;;;;spielfrei;;2;Herren`
+11.10.2022 11:45;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;spielfrei;;2;Herren`
 
 const emptyHalleAppointment = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse
 12.10.2022 11:45;3. KK West;VR;VfL Hamburg;;;;;spielfrei;;2;Herren`

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -55,7 +55,7 @@ describe('Parse Click-TT CSV file', () => {
             const actualAppointment = actualAppointments.values().next().value
 
             // then
-            expect(actualAppointment.address).toEqual("");
+            expect(actualAppointment.location).toEqual("");
         })
     })
 

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -16,7 +16,7 @@ class TestFileStorageService implements FileStorageService {
     constructor(private readonly fileContent: string) {}
 
     readFile(filename: string): Buffer {
-        return Buffer.from(fileContent)
+        return Buffer.from(this.fileContent)
     }
 }
 

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -9,7 +9,7 @@ const defaultAppointments = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;Ha
 11.10.2022 11:45;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;spielfrei;;2;Herren`
 
 const emptyHalleAppointment = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse
-12.10.2022 11:45;3. KK West;VR;VfL Hamburg;;;;;spielfrei;;2;Herren`
+12.10.2022 11:45;3. KK West;VR;VfL Hamburg;;;;;SC Lübeck;;2;Herren`
 
 class TestFileStorageService implements FileStorageService {
     constructor(private readonly fileContent: string) {}


### PR DESCRIPTION
# Description

In case the address data of the gym was not given, the appointment was initialized with `, , ` which looks ugly and is wrong. This PR will not show anything in case the address fields are empty.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
