### PR TITLE
refactor: use injected absolute file paths in repositories

### DIFF
--- a/src/adapter/CdiContainer.ts
+++ b/src/adapter/CdiContainer.ts
@@ -1,4 +1,5 @@
 import { Container } from "inversify";
+import * as path from "node:path";
 
 import { SERVICE_IDENTIFIER } from "../dependency_injection";
 import { LoggerImpl } from "./LoggerImpl";
@@ -41,12 +42,19 @@ export class CdiContainer {
         this.container.bind<AppointmentParserService>(SERVICE_IDENTIFIER.AppointmentParserService).to(ClickTtCsvFileAppointmentParserServiceImpl).inSingletonScope();
         this.container.bind<CalendarService>(SERVICE_IDENTIFIER.CalendarService).to(CalDavCalendarServiceImpl).inSingletonScope();
         this.container.bind<FileStorageService>(SERVICE_IDENTIFIER.FileStorageService).to(LocalFileStorageServiceImpl).inSingletonScope();
-        this.container.bind<SportsHallRepository>(SERVICE_IDENTIFIER.SportsHallRepository).to(FileSportsHallRepositoryImpl).inSingletonScope();
+        this.container.bind<SportsHallRepository>(SERVICE_IDENTIFIER.SportsHallRepository).toDynamicValue((context) => {
+            const fileStorageService = context.container.get<FileStorageService>(SERVICE_IDENTIFIER.FileStorageService);
+            const remoteService = context.container.get<SportsHallRemoteService>(SERVICE_IDENTIFIER.SportsHallRemoteService);
+            const logger = context.container.get<LoggerImpl>(SERVICE_IDENTIFIER.Logger);
+            const filePath = path.join(process.cwd(), "sports_halls.json");
+            return new FileSportsHallRepositoryImpl(filePath, fileStorageService, remoteService, logger);
+        }).inSingletonScope();
         this.container.bind<LoggerImpl>(SERVICE_IDENTIFIER.Logger).toConstantValue(new LoggerImpl(new winston.transports.Console()));
         this.container.bind<TeamLeadRepository>(SERVICE_IDENTIFIER.TeamLeadRepository).toDynamicValue((context) => {
+            const filePath = path.join(process.cwd(), "team_leads.json");
             const fileStorageService = context.container.get<FileStorageService>(SERVICE_IDENTIFIER.FileStorageService);
             const logger = context.container.get<LoggerImpl>(SERVICE_IDENTIFIER.Logger);
-            return new FileTeamLeadRepositoryImpl(fileStorageService, logger);
+            return new FileTeamLeadRepositoryImpl(filePath, fileStorageService, logger);
         }).inSingletonScope();
         this.container.bind<WebPageService>(SERVICE_IDENTIFIER.WebPageService).to(AxiosWebPageService).inSingletonScope();
         this.container.bind<SportsHallRemoteService>(SERVICE_IDENTIFIER.SportsHallRemoteService).to(HttpSportsHallRemoteService).inSingletonScope();

--- a/src/adapter/service/FileSportsHallRepositoryImpl.ts
+++ b/src/adapter/service/FileSportsHallRepositoryImpl.ts
@@ -19,11 +19,12 @@ export class FileSportsHallRepositoryImpl extends FileCachedRepository<SportsHal
     }
 
     constructor(
+        filePath: string,
         @inject(SERVICE_IDENTIFIER.FileStorageService) fileStorageService: FileStorageService,
         @inject(SERVICE_IDENTIFIER.SportsHallRemoteService) private readonly sportsHallRemoteService: SportsHallRemoteService,
         @inject(SERVICE_IDENTIFIER.Logger) logger: LoggerImpl
     ) {
-        super("sports_halls.json", fileStorageService, logger);
+        super(filePath, fileStorageService, logger);
     }
 
     protected isSamePrimaryKey(a: SportsHall, b: SportsHall): boolean {

--- a/src/adapter/service/FileTeamLeadRepositoryImpl.ts
+++ b/src/adapter/service/FileTeamLeadRepositoryImpl.ts
@@ -13,10 +13,11 @@ import { FileCachedRepository } from "./CachedRepository";
 @injectable()
 export class FileTeamLeadRepositoryImpl extends FileCachedRepository<TeamLead> implements TeamLeadRepository {
     constructor(
+        filePath: string,
         @inject(SERVICE_IDENTIFIER.FileStorageService) fileStorageService: FileStorageService,
         @inject(SERVICE_IDENTIFIER.Logger) logger: LoggerImpl
     ) {
-        super("team_leads.json", fileStorageService, logger);
+        super(filePath, fileStorageService, logger);
     }
 
     protected isSamePrimaryKey(a: TeamLead, b: TeamLead): boolean {

--- a/tests/adapter/service/FileSportsHallRepositoryImpl.infra.spec.ts
+++ b/tests/adapter/service/FileSportsHallRepositoryImpl.infra.spec.ts
@@ -16,7 +16,6 @@ describe('FileSportsHallRepositoryImpl', () => {
 
     const testDataDir = path.join(__dirname, '../../../target/test-data');
     const testFilePath = path.join(testDataDir, 'sports_halls.json');
-    const originalCwd = process.cwd();
 
     const sampleData: SportsHall[] = [
         {
@@ -71,19 +70,13 @@ describe('FileSportsHallRepositoryImpl', () => {
                 transports: [new winston.transports.Console({ silent: true })],
             })
         );
-
-        // Change to test directory so LocalFileStorageServiceImpl uses relative paths to find the test file
-        process.chdir(testDataDir);
     });
 
     beforeEach(() => {
-        repo = new FileSportsHallRepositoryImpl(storageService, remoteService, infraLogger);
+        repo = new FileSportsHallRepositoryImpl(testFilePath, storageService, remoteService, infraLogger);
     });
 
     afterAll(() => {
-        // Restore original directory
-        process.chdir(originalCwd);
-
         // Clean up test files
         if (fs.existsSync(testFilePath)) {
             fs.unlinkSync(testFilePath);

--- a/tests/adapter/service/FileSportsHallRepositoryImpl.spec.ts
+++ b/tests/adapter/service/FileSportsHallRepositoryImpl.spec.ts
@@ -38,6 +38,7 @@ describe('FileSportsHallRepositoryImpl', () => {
         jest.clearAllMocks();
 
         repo = new FileSportsHallRepositoryImpl(
+            '/test/path/sports_halls.json',
             mockFileStorageService,
             mockRemoteService,
             mockLogger

--- a/tests/adapter/service/FileTeamLeadRepositoryImpl.infra.spec.ts
+++ b/tests/adapter/service/FileTeamLeadRepositoryImpl.infra.spec.ts
@@ -12,7 +12,6 @@ describe('FileTeamLeadRepositoryImpl', () => {
 
     const testDataDir = path.join(__dirname, '../../../target/test-data');
     const testFilePath = path.join(testDataDir, 'team_leads.json');
-    const originalCwd = process.cwd();
 
     const sampleData = {
         VR: [
@@ -57,19 +56,13 @@ describe('FileTeamLeadRepositoryImpl', () => {
                 transports: [new winston.transports.Console({ silent: true })],
             })
         );
-
-        // Change to test directory so LocalFileStorageServiceImpl uses relative paths to find the test file
-        process.chdir(testDataDir);
     });
 
     beforeEach(() => {
-        repo = new FileTeamLeadRepositoryImpl(storageService, infraLogger);
+        repo = new FileTeamLeadRepositoryImpl(testFilePath, storageService, infraLogger);
     });
 
     afterAll(() => {
-        // Restore original directory
-        process.chdir(originalCwd);
-
         // Clean up test files
         if (fs.existsSync(testFilePath)) {
             fs.unlinkSync(testFilePath);

--- a/tests/adapter/service/FileTeamLeadRepositoryImpl.spec.ts
+++ b/tests/adapter/service/FileTeamLeadRepositoryImpl.spec.ts
@@ -21,7 +21,7 @@ describe('FileTeamLeadRepositoryImpl', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        repo = new FileTeamLeadRepositoryImpl(mockFileStorageService, mockLogger);
+        repo = new FileTeamLeadRepositoryImpl('/test/path/team_leads.json', mockFileStorageService, mockLogger);
     });
 
 


### PR DESCRIPTION
Refactor FileCachedRepository and its implementations to use dependency-injected absolute file paths instead of computing them at runtime. This eliminates the need for process.cwd() manipulation in tests and improves separation of concerns.