### PR TITLE
fix: trim spaces from location fields

### DIFF
--- a/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
+++ b/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
@@ -107,7 +107,7 @@ export class ClickTtCsvFileAppointmentParserServiceImpl implements AppointmentPa
                             try {
                                 const startDateTime = LocalDateTime.parse(cleanedTermin, csvDateTimeFormatter)
                                 if (data.GastVereinName != 'spielfrei') {
-                                    const location = data.HalleName || data.HalleStrasse || data.HallePLZ || data.HalleOrt ? data.HalleName + ", " + data.HalleStrasse + ", " + data.HallePLZ + " " + data.HalleOrt : '';
+                                    const location = data.HalleName || data.HalleStrasse || data.HallePLZ || data.HalleOrt ? data.HalleName?.trim() + ", " + data.HalleStrasse?.trim() + ", " + data.HallePLZ?.trim() + " " + data.HalleOrt?.trim() : '';
                                     const isCup = data.Runde == 'Pokal'
 
                                     // Look up team lead for the home team with age class and round

--- a/src/adapter/service/FileSportsHallRepositoryImpl.ts
+++ b/src/adapter/service/FileSportsHallRepositoryImpl.ts
@@ -31,6 +31,7 @@ export class FileSportsHallRepositoryImpl extends FileCachedRepository<SportsHal
         return FileSportsHallRepositoryImpl.isSamePrimaryKeyImpl(a, b);
     }
 
+
     async find(key: SportsHallKey, club: Club): Promise<SportsHall | undefined> {
         const sportsHalls = await this.getAll();
         let hall = sportsHalls.find(hall => FileSportsHallRepositoryImpl.isSamePrimaryKeyImpl(hall, key));

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -134,4 +134,13 @@ describe('Parse Click-TT CSV file', () => {
             expect(actualAppointments.size).toEqual(0);
         })
     });
+
+    it('should_trim_leading_spaces_from_location_fields', () => {
+        const csvWithLeadingSpaces = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse\n10.10.2022 11:45;3. KK West;VR;VfL Hamburg; Lübecker Straße 4; Lübeck; 23456; Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren`;
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithLeadingSpaces), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        return parser.parseAppointments("abc.csv").then(actualAppointments => {
+            const actualAppointment = actualAppointments.values().next().value
+            expect(actualAppointment.location).toEqual("Holstenhalle, Lübecker Straße 4, 23456 Lübeck");
+        })
+    });
 })


### PR DESCRIPTION
Fix a data integrity bug where location fields in CSV appointments and sports halls JSON contained leading spaces, resulting in malformed venue information. The parser now safely handles whitespace in source data.