### PR TITLE
refactor: replace LoggerImpl with Logger interface

### DIFF
--- a/src/adapter/CdiContainer.ts
+++ b/src/adapter/CdiContainer.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 
 import { SERVICE_IDENTIFIER } from "../dependency_injection";
 import { LoggerImpl } from "./LoggerImpl";
+import { Logger } from "../domain/service/Logger";
 import { SyncCalendarApplicationService } from "../application/SyncCalendarApplicationService";
 import { AppointmentParserService } from "../domain/service/AppointmentParserService";
 import { ClickTtCsvFileAppointmentParserServiceImpl } from "./service/ClickTtCsvFileAppointmentParserServiceImpl";
@@ -45,15 +46,15 @@ export class CdiContainer {
         this.container.bind<SportsHallRepository>(SERVICE_IDENTIFIER.SportsHallRepository).toDynamicValue((context) => {
             const fileStorageService = context.container.get<FileStorageService>(SERVICE_IDENTIFIER.FileStorageService);
             const remoteService = context.container.get<SportsHallRemoteService>(SERVICE_IDENTIFIER.SportsHallRemoteService);
-            const logger = context.container.get<LoggerImpl>(SERVICE_IDENTIFIER.Logger);
+            const logger = context.container.get<Logger>(SERVICE_IDENTIFIER.Logger);
             const filePath = path.join(process.cwd(), "sports_halls.json");
             return new FileSportsHallRepositoryImpl(filePath, fileStorageService, remoteService, logger);
         }).inSingletonScope();
-        this.container.bind<LoggerImpl>(SERVICE_IDENTIFIER.Logger).toConstantValue(new LoggerImpl(new winston.transports.Console()));
+        this.container.bind<Logger>(SERVICE_IDENTIFIER.Logger).toConstantValue(new LoggerImpl(new winston.transports.Console()));
         this.container.bind<TeamLeadRepository>(SERVICE_IDENTIFIER.TeamLeadRepository).toDynamicValue((context) => {
             const filePath = path.join(process.cwd(), "team_leads.json");
             const fileStorageService = context.container.get<FileStorageService>(SERVICE_IDENTIFIER.FileStorageService);
-            const logger = context.container.get<LoggerImpl>(SERVICE_IDENTIFIER.Logger);
+            const logger = context.container.get<Logger>(SERVICE_IDENTIFIER.Logger);
             return new FileTeamLeadRepositoryImpl(filePath, fileStorageService, logger);
         }).inSingletonScope();
         this.container.bind<WebPageService>(SERVICE_IDENTIFIER.WebPageService).to(AxiosWebPageService).inSingletonScope();

--- a/src/adapter/LoggerImpl.ts
+++ b/src/adapter/LoggerImpl.ts
@@ -1,10 +1,11 @@
 
 import { injectable } from 'inversify';
 import winston, { format } from 'winston';
+import { Logger } from '../domain/service/Logger';
 
 @injectable()
-export class LoggerImpl {
-    private logger: winston.Logger;
+export class LoggerImpl implements Logger {
+    private readonly logger: winston.Logger;
 
     constructor(transport: winston.transport) {
         this.logger = winston.createLogger({

--- a/src/adapter/service/CachedRepository.ts
+++ b/src/adapter/service/CachedRepository.ts
@@ -1,5 +1,5 @@
 import { injectable } from "inversify";
-import { LoggerImpl } from "../LoggerImpl";
+import { Logger } from "../../domain/service/Logger";
 
 /**
  * Abstract concurrency-safe, cached repository for any entity type.
@@ -17,7 +17,7 @@ export abstract class FileCachedRepository<T> {
     constructor(
         protected readonly filePath: string,
         protected readonly fileStorageService: { readFile: (file: string) => Promise<string>; writeFile: (file: string, content: string) => Promise<void> },
-        protected readonly logger: LoggerImpl
+        protected readonly logger: Logger
     ) {}
 
     /**

--- a/src/adapter/service/CalDavCalendarServiceImpl.ts
+++ b/src/adapter/service/CalDavCalendarServiceImpl.ts
@@ -10,7 +10,7 @@ import { Appointment, AppointmentFactory, AppointmentInterface } from "../../dom
 import { CalendarService } from "../../domain/service/CalendarService";
 import { TeamLeadRepository } from "../../domain/service/TeamLeadRepository";
 import { TeamLead } from "../../domain/model/TeamLead";
-import { LoggerImpl } from "../LoggerImpl";
+import { Logger } from "../../domain/service/Logger";
 
 /**
  * Reads all events from a certain calendar. Events must be linked to category 'Click-TT'
@@ -18,11 +18,11 @@ import { LoggerImpl } from "../LoggerImpl";
 @injectable()
 export class CalDavCalendarServiceImpl implements CalendarService {
     private readonly client: DAVClient;
-    private readonly logger: LoggerImpl;
+    private readonly logger: Logger;
     private readonly teamLeadRepository: TeamLeadRepository;
     private calendar: DAVCalendar | undefined;
 
-    constructor(@inject(CONFIGURATION.CalendarUrl) readonly url: string, @inject(CONFIGURATION.CalendarUsername) readonly username: string, @inject(CONFIGURATION.CalendarPassword) readonly password: string, @inject(SERVICE_IDENTIFIER.Logger) logger: LoggerImpl, @inject(SERVICE_IDENTIFIER.TeamLeadRepository) teamLeadRepository: TeamLeadRepository) {
+    constructor(@inject(CONFIGURATION.CalendarUrl) readonly url: string, @inject(CONFIGURATION.CalendarUsername) readonly username: string, @inject(CONFIGURATION.CalendarPassword) readonly password: string, @inject(SERVICE_IDENTIFIER.Logger) logger: Logger, @inject(SERVICE_IDENTIFIER.TeamLeadRepository) teamLeadRepository: TeamLeadRepository) {
         this.client = new DAVClient({
             serverUrl: this.url,
             credentials: {

--- a/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
+++ b/src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.ts
@@ -3,7 +3,7 @@ import { AppointmentFactory, AppointmentInterface } from "../../domain/model/App
 import { AppointmentParserService } from "../../domain/service/AppointmentParserService";
 import { inject, injectable } from 'inversify';
 import { SERVICE_IDENTIFIER, CONFIGURATION } from '../../dependency_injection';
-import { LoggerImpl } from '../LoggerImpl';
+import { Logger } from '../../domain/service/Logger';
 import { FileStorageService } from '../../domain/service/FileStorageService';
 import { TeamLeadRepository } from '../../domain/service/TeamLeadRepository';
 import { TeamLead } from '../../domain/model/TeamLead';
@@ -60,7 +60,7 @@ type ClickTtCsvFile = {
 export class ClickTtCsvFileAppointmentParserServiceImpl implements AppointmentParserService {
     constructor(
         @inject(SERVICE_IDENTIFIER.FileStorageService) readonly fileStorageService: FileStorageService,
-        @inject(SERVICE_IDENTIFIER.Logger) readonly logger: LoggerImpl,
+        @inject(SERVICE_IDENTIFIER.Logger) readonly logger: Logger,
         @inject(SERVICE_IDENTIFIER.TeamLeadRepository) readonly teamLeadRepository: TeamLeadRepository,
         @inject(CONFIGURATION.ClubName) readonly clubName: string
     ) { }

--- a/src/adapter/service/FileSportsHallRepositoryImpl.ts
+++ b/src/adapter/service/FileSportsHallRepositoryImpl.ts
@@ -5,7 +5,7 @@ import { Club } from "../../domain/model/Club";
 import { SERVICE_IDENTIFIER } from "../../dependency_injection";
 import { FileStorageService } from "../../domain/service/FileStorageService";
 import { SportsHallRemoteService } from "../../domain/service/SportsHallRemoteService";
-import { LoggerImpl } from "../LoggerImpl";
+import { Logger } from "../../domain/service/Logger";
 import { FileCachedRepository } from "./CachedRepository";
 
 /**
@@ -22,7 +22,7 @@ export class FileSportsHallRepositoryImpl extends FileCachedRepository<SportsHal
         filePath: string,
         @inject(SERVICE_IDENTIFIER.FileStorageService) fileStorageService: FileStorageService,
         @inject(SERVICE_IDENTIFIER.SportsHallRemoteService) private readonly sportsHallRemoteService: SportsHallRemoteService,
-        @inject(SERVICE_IDENTIFIER.Logger) logger: LoggerImpl
+        @inject(SERVICE_IDENTIFIER.Logger) logger: Logger
     ) {
         super(filePath, fileStorageService, logger);
     }

--- a/src/adapter/service/FileTeamLeadRepositoryImpl.ts
+++ b/src/adapter/service/FileTeamLeadRepositoryImpl.ts
@@ -3,7 +3,7 @@ import { TeamLead } from "../../domain/model/TeamLead";
 import { TeamLeadRepository } from "../../domain/service/TeamLeadRepository";
 import { SERVICE_IDENTIFIER } from "../../dependency_injection";
 import { FileStorageService } from "../../domain/service/FileStorageService";
-import { LoggerImpl } from "../LoggerImpl";
+import { Logger } from "../../domain/service/Logger";
 import { FileCachedRepository } from "./CachedRepository";
 
 /**
@@ -15,7 +15,7 @@ export class FileTeamLeadRepositoryImpl extends FileCachedRepository<TeamLead> i
     constructor(
         filePath: string,
         @inject(SERVICE_IDENTIFIER.FileStorageService) fileStorageService: FileStorageService,
-        @inject(SERVICE_IDENTIFIER.Logger) logger: LoggerImpl
+        @inject(SERVICE_IDENTIFIER.Logger) logger: Logger
     ) {
         super(filePath, fileStorageService, logger);
     }

--- a/src/application/SyncCalendarApplicationService.ts
+++ b/src/application/SyncCalendarApplicationService.ts
@@ -1,7 +1,7 @@
 import { ZoneId } from "@js-joda/core";
 import '@js-joda/timezone';
 import { inject, injectable } from "inversify";
-import { LoggerImpl } from "../adapter/LoggerImpl";
+import { Logger } from "../domain/service/Logger";
 import { SERVICE_IDENTIFIER } from "../dependency_injection";
 import { Appointment, AppointmentInterface } from "../domain/model/Appointment";
 import { AppointmentParserService } from "../domain/service/AppointmentParserService";
@@ -18,7 +18,7 @@ export class SyncCalendarApplicationService {
         @inject(SERVICE_IDENTIFIER.AppointmentParserService) readonly appointmentParserService: AppointmentParserService,
         @inject(SERVICE_IDENTIFIER.CalendarService) readonly calendarService: CalendarService,
         @inject(SERVICE_IDENTIFIER.FileStorageService) readonly fileStorageService: FileStorageService,
-        @inject(SERVICE_IDENTIFIER.Logger) readonly logger: LoggerImpl,
+        @inject(SERVICE_IDENTIFIER.Logger) readonly logger: Logger,
         @inject(SERVICE_IDENTIFIER.SportsHallRepository) readonly sportsHallRepository: SportsHallRepository
     ) { }
 

--- a/src/domain/service/Logger.ts
+++ b/src/domain/service/Logger.ts
@@ -1,0 +1,30 @@
+/**
+ * Interface for logging functionality
+ */
+export interface Logger {
+    /**
+     * Log an error message
+     */
+    error(message: any): void;
+
+    /**
+     * Log a warning message
+     */
+    warning(message: any): void;
+
+    /**
+     * Log an info message
+     */
+    info(message: any): void;
+
+    /**
+     * Log a debug message
+     */
+    debug(message: any): void;
+
+    /**
+     * Log a trace message
+     */
+    trace(message: any): void;
+}
+

--- a/tests/adapter/CdiContainer.spec.ts
+++ b/tests/adapter/CdiContainer.spec.ts
@@ -1,5 +1,5 @@
 import { CdiContainer, container } from "../../src/adapter/CdiContainer";
-import { LoggerImpl } from "../../src/adapter/LoggerImpl";
+import { Logger } from "../../src/domain/service/Logger";
 import { CalDavCalendarServiceImpl } from "../../src/adapter/service/CalDavCalendarServiceImpl";
 import { ClickTtCsvFileAppointmentParserServiceImpl } from "../../src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl";
 import { LocalFileStorageServiceImpl } from "../../src/adapter/service/LocalFileStorageServiceImpl";
@@ -24,7 +24,16 @@ describe('CDI Container', () => {
         expect(container.getService(SERVICE_IDENTIFIER.AppointmentParserService)).toBeInstanceOf(ClickTtCsvFileAppointmentParserServiceImpl)
         expect(container.getService(SERVICE_IDENTIFIER.CalendarService)).toBeInstanceOf(CalDavCalendarServiceImpl)
         expect(container.getService(SERVICE_IDENTIFIER.FileStorageService)).toBeInstanceOf(LocalFileStorageServiceImpl)
-        expect(container.getService(SERVICE_IDENTIFIER.Logger)).toBeInstanceOf(LoggerImpl)
+
+        // Verify logger is a Logger interface implementation
+        const logger = container.getService(SERVICE_IDENTIFIER.Logger) as Logger;
+        expect(logger).toBeDefined();
+        expect(typeof logger.error).toBe('function');
+        expect(typeof logger.warning).toBe('function');
+        expect(typeof logger.info).toBe('function');
+        expect(typeof logger.debug).toBe('function');
+        expect(typeof logger.trace).toBe('function');
+
         expect(container.getService(SERVICE_IDENTIFIER.TeamLeadRepository)).toBeDefined()
     })
 

--- a/tests/adapter/Logger.spec.ts
+++ b/tests/adapter/Logger.spec.ts
@@ -24,6 +24,8 @@ class TestStringTransport extends Transport {
 };
 
 describe('Logger', () => {
+    // LoggerImpl is intentionally instantiated here because this test suite
+    // is specifically testing the LoggerImpl adapter implementation
     const loggerOutput = new TestStringTransport()
     const logger = new LoggerImpl(loggerOutput)
 

--- a/tests/adapter/service/CachedRepository.spec.ts
+++ b/tests/adapter/service/CachedRepository.spec.ts
@@ -1,4 +1,5 @@
 import { FileCachedRepository } from '../../../src/adapter/service/CachedRepository';
+import { MockLogger } from '../../test-utils/MockLogger';
 
 // Simple entity for testing
 interface TestEntity {
@@ -6,11 +7,6 @@ interface TestEntity {
     value: string;
 }
 
-// Mock logger
-class MockLogger {
-    public errors: any[] = [];
-    error(message: any) { this.errors.push(message); }
-}
 
 // Mock file storage
 class MockFileStorage {
@@ -48,7 +44,6 @@ describe('FileCachedRepository', () => {
     beforeEach(() => {
         storage = new MockFileStorage();
         logger = new MockLogger();
-        // @ts-ignore: LoggerImpl type
         repo = new TestFileCachedRepository(filePath, storage, logger);
     });
 

--- a/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
+++ b/tests/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl.spec.ts
@@ -1,10 +1,9 @@
 import { LocalDateTime } from "@js-joda/core"
-import winston from 'winston'
-import { LoggerImpl } from "../../../src/adapter/LoggerImpl"
 import { ClickTtCsvFileAppointmentParserServiceImpl } from "../../../src/adapter/service/ClickTtCsvFileAppointmentParserServiceImpl"
 import { FileStorageService } from "../../../src/domain/service/FileStorageService"
 import { TeamLeadRepository } from "../../../src/domain/service/TeamLeadRepository"
 import { TeamLead } from "../../../src/domain/model/TeamLead"
+import { MockLogger } from "../../test-utils/MockLogger"
 
 const defaultAppointments = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse
 10.10.2022 11:45;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren
@@ -44,15 +43,10 @@ class TestTeamLeadRepository implements TeamLeadRepository {
     }
 }
 
-class TestLogger extends LoggerImpl {
-    constructor() {
-        super(new winston.transports.Console())
-    }
-}
 
 describe('Parse Click-TT CSV file', () => {
     it('should create appointment from CSV data', () => {
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
 
         // when
         parser.parseAppointments("abc.csv").then(actualAppointments => {
@@ -62,7 +56,7 @@ describe('Parse Click-TT CSV file', () => {
     })
 
     it('should ignore "spielfrei" appointments', () => {
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
 
         // when
         parser.parseAppointments("abc.csv").then(actualAppointments => {
@@ -72,7 +66,7 @@ describe('Parse Click-TT CSV file', () => {
     })
 
     it('should show empty address if address fields are not filled', () => {
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(emptyHalleAppointment), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(emptyHalleAppointment), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
 
         // when
         parser.parseAppointments("abc.csv").then(actualAppointments => {
@@ -84,7 +78,7 @@ describe('Parse Click-TT CSV file', () => {
     })
 
     it('should extract necessary data from CSV data', () => {
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(defaultAppointments), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
 
         // when
         parser.parseAppointments("abc.csv").then(actualAppointments => {
@@ -103,7 +97,7 @@ describe('Parse Click-TT CSV file', () => {
 
     it('should_parse_date_with_day_of_week_prefix_when_processing_german_date_format', () => {
         const csvWithDayOfWeek = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse\nMo., 25.08.2025 20:15;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren`;
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithDayOfWeek), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithDayOfWeek), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
         parser.parseAppointments("abc.csv").then(actualAppointments => {
             const actualAppointment = actualAppointments.values().next().value
             expect(actualAppointment.startDateTime).toEqual(LocalDateTime.parse("2025-08-25T20:15"));
@@ -112,7 +106,7 @@ describe('Parse Click-TT CSV file', () => {
 
     it('should_strip_trailing_v_character_when_appointment_was_moved', () => {
         const csvWithTrailingV = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse\n16.09.2025 20:30v;3. KK West;VR;VfL Hamburg;Lübecker Straße 4;Lübeck;23456;Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren`;
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithTrailingV), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithTrailingV), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
         parser.parseAppointments("abc.csv").then(actualAppointments => {
             const actualAppointment = actualAppointments.values().next().value
             expect(actualAppointment.startDateTime).toEqual(LocalDateTime.parse("2025-09-16T20:30"));
@@ -121,7 +115,7 @@ describe('Parse Click-TT CSV file', () => {
 
     it('should_handle_malformed_date_time_gracefully', () => {
         const csvMalformed = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse\nnot-a-date;3. KK West;VR;VfL Hamburg;;;;SC Lübeck;;2;Herren`;
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvMalformed), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvMalformed), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
         parser.parseAppointments("abc.csv").then(actualAppointments => {
             expect(actualAppointments.size).toEqual(0);
         })
@@ -129,7 +123,7 @@ describe('Parse Click-TT CSV file', () => {
 
     it('should_handle_missing_columns_gracefully', () => {
         const csvMissingCols = `Termin;Staffel;Runde;HeimMannschaft\n10.10.2022 11:45;3. KK West;VR;VfL Hamburg`;
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvMissingCols), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvMissingCols), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
         parser.parseAppointments("abc.csv").then(actualAppointments => {
             expect(actualAppointments.size).toEqual(0);
         })
@@ -137,7 +131,7 @@ describe('Parse Click-TT CSV file', () => {
 
     it('should_trim_leading_spaces_from_location_fields', () => {
         const csvWithLeadingSpaces = `Termin;Staffel;Runde;HeimMannschaft;HalleStrasse;HalleOrt;HallePLZ;HalleName;GastVereinName;GastMannschaft;BegegnungNr;Altersklasse\n10.10.2022 11:45;3. KK West;VR;VfL Hamburg; Lübecker Straße 4; Lübeck; 23456; Holstenhalle;SC Lübeck;SC Lübeck III;2;Herren`;
-        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithLeadingSpaces), new TestLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
+        const parser = new ClickTtCsvFileAppointmentParserServiceImpl(new TestFileStorageService(csvWithLeadingSpaces), new MockLogger(), new TestTeamLeadRepository(), "SC Kleckersdorf")
         return parser.parseAppointments("abc.csv").then(actualAppointments => {
             const actualAppointment = actualAppointments.values().next().value
             expect(actualAppointment.location).toEqual("Holstenhalle, Lübecker Straße 4, 23456 Lübeck");

--- a/tests/adapter/service/FileSportsHallRepositoryImpl.infra.spec.ts
+++ b/tests/adapter/service/FileSportsHallRepositoryImpl.infra.spec.ts
@@ -3,16 +3,16 @@ import { LocalFileStorageServiceImpl } from '../../../src/adapter/service/LocalF
 import { HttpSportsHallRemoteService } from '../../../src/adapter/service/HttpSportsHallRemoteService';
 import { SportsHall } from '../../../src/domain/model/SportsHall';
 import { Club } from '../../../src/domain/model/Club';
-import { LoggerImpl } from '../../../src/adapter/LoggerImpl';
+import { Logger } from '../../../src/domain/service/Logger';
+import { MockLogger } from '../../test-utils/MockLogger';
 import * as fs from 'fs';
 import * as path from 'path';
-import winston from 'winston';
 
 describe('FileSportsHallRepositoryImpl', () => {
     let repo: FileSportsHallRepositoryImpl;
     let storageService: LocalFileStorageServiceImpl;
     let remoteService: HttpSportsHallRemoteService;
-    let infraLogger: LoggerImpl;
+    let infraLogger: Logger;
 
     const testDataDir = path.join(__dirname, '../../../target/test-data');
     const testFilePath = path.join(testDataDir, 'sports_halls.json');
@@ -65,11 +65,7 @@ describe('FileSportsHallRepositoryImpl', () => {
         } as unknown as HttpSportsHallRemoteService;
 
         // Create logger
-        infraLogger = new LoggerImpl(
-            winston.createLogger({
-                transports: [new winston.transports.Console({ silent: true })],
-            })
-        );
+        infraLogger = new MockLogger();
     });
 
     beforeEach(() => {

--- a/tests/adapter/service/FileSportsHallRepositoryImpl.spec.ts
+++ b/tests/adapter/service/FileSportsHallRepositoryImpl.spec.ts
@@ -3,7 +3,7 @@ import { FileStorageService } from '../../../src/domain/service/FileStorageServi
 import { SportsHallRemoteService } from '../../../src/domain/service/SportsHallRemoteService';
 import { SportsHall } from '../../../src/domain/model/SportsHall';
 import { Club } from "../../../src/domain/model/Club";
-import { LoggerImpl } from '../../../src/adapter/LoggerImpl';
+import { MockLogger } from '../../test-utils/MockLogger';
 
 // Mocks
 const mockFileStorageService: FileStorageService = {
@@ -14,12 +14,7 @@ const mockFileStorageService: FileStorageService = {
 const mockRemoteService: SportsHallRemoteService = {
     fetchSportsHalls: jest.fn(),
 };
-const mockLogger: LoggerImpl = {
-    error: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    debug: jest.fn(),
-} as unknown as LoggerImpl;
+const mockLogger = new MockLogger();
 
 describe('FileSportsHallRepositoryImpl', () => {
     let repo: FileSportsHallRepositoryImpl;

--- a/tests/adapter/service/FileTeamLeadRepositoryImpl.infra.spec.ts
+++ b/tests/adapter/service/FileTeamLeadRepositoryImpl.infra.spec.ts
@@ -1,14 +1,14 @@
 import { FileTeamLeadRepositoryImpl } from '../../../src/adapter/service/FileTeamLeadRepositoryImpl';
 import { LocalFileStorageServiceImpl } from '../../../src/adapter/service/LocalFileStorageServiceImpl';
-import { LoggerImpl } from '../../../src/adapter/LoggerImpl';
+import { Logger } from '../../../src/domain/service/Logger';
+import { MockLogger } from '../../test-utils/MockLogger';
 import * as fs from 'fs';
 import * as path from 'path';
-import winston from 'winston';
 
 describe('FileTeamLeadRepositoryImpl', () => {
     let repo: FileTeamLeadRepositoryImpl;
     let storageService: LocalFileStorageServiceImpl;
-    let infraLogger: LoggerImpl;
+    let infraLogger: Logger;
 
     const testDataDir = path.join(__dirname, '../../../target/test-data');
     const testFilePath = path.join(testDataDir, 'team_leads.json');
@@ -51,11 +51,7 @@ describe('FileTeamLeadRepositoryImpl', () => {
         storageService = new LocalFileStorageServiceImpl();
 
         // Create logger
-        infraLogger = new LoggerImpl(
-            winston.createLogger({
-                transports: [new winston.transports.Console({ silent: true })],
-            })
-        );
+        infraLogger = new MockLogger();
     });
 
     beforeEach(() => {

--- a/tests/adapter/service/FileTeamLeadRepositoryImpl.spec.ts
+++ b/tests/adapter/service/FileTeamLeadRepositoryImpl.spec.ts
@@ -1,7 +1,7 @@
 import { FileTeamLeadRepositoryImpl } from '../../../src/adapter/service/FileTeamLeadRepositoryImpl';
 import { FileStorageService } from '../../../src/domain/service/FileStorageService';
 import { TeamLead } from '../../../src/domain/model/TeamLead';
-import { LoggerImpl } from '../../../src/adapter/LoggerImpl';
+import { MockLogger } from '../../test-utils/MockLogger';
 
 // Mocks
 const mockFileStorageService: FileStorageService = {
@@ -9,12 +9,7 @@ const mockFileStorageService: FileStorageService = {
     writeFile: jest.fn(),
     deleteFile: jest.fn(),
 };
-const mockLogger: LoggerImpl = {
-    error: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    debug: jest.fn(),
-} as unknown as LoggerImpl;
+const mockLogger = new MockLogger();
 
 describe('FileTeamLeadRepositoryImpl', () => {
     let repo: FileTeamLeadRepositoryImpl;

--- a/tests/test-utils/MockLogger.ts
+++ b/tests/test-utils/MockLogger.ts
@@ -1,0 +1,59 @@
+import { Logger } from '../../src/domain/service/Logger';
+
+/**
+ * Mock logger implementation for testing.
+ * Implements the Logger interface with no-op methods suitable for unit tests.
+ */
+export class MockLogger implements Logger {
+    public errors: any[] = [];
+    public warnings: any[] = [];
+    public infos: any[] = [];
+    public debugs: any[] = [];
+    public traces: any[] = [];
+
+    error(message: any): void {
+        this.errors.push(message);
+    }
+
+    warning(message: any): void {
+        this.warnings.push(message);
+    }
+
+    info(message: any): void {
+        this.infos.push(message);
+    }
+
+    debug(message: any): void {
+        this.debugs.push(message);
+    }
+
+    trace(message: any): void {
+        this.traces.push(message);
+    }
+
+    /**
+     * Reset all collected messages.
+     * Useful in beforeEach hooks to clear state between tests.
+     */
+    reset(): void {
+        this.errors = [];
+        this.warnings = [];
+        this.infos = [];
+        this.debugs = [];
+        this.traces = [];
+    }
+
+    /**
+     * Get all collected messages in a single array, ordered by log level.
+     */
+    getAllMessages(): any[] {
+        return [
+            ...this.errors,
+            ...this.warnings,
+            ...this.infos,
+            ...this.debugs,
+            ...this.traces,
+        ];
+    }
+}
+


### PR DESCRIPTION
This PR introduces a Logger interface to decouple the logging abstraction from its concrete implementation (LoggerImpl). This improves code maintainability, testability, and follows SOLID principles.

Previously, the codebase directly depended on the concrete LoggerImpl class throughout the application. This tight coupling made it harder to:

- Mock logging in tests
- Swap logging implementations without refactoring multiple files
- Maintain clean architectural boundaries between domain and adapter layers