### PR TITLE
chore: inject log level into the logger implementation

### DIFF
--- a/src/adapter/LoggerImpl.ts
+++ b/src/adapter/LoggerImpl.ts
@@ -7,10 +7,10 @@ import { Logger } from '../domain/service/Logger';
 export class LoggerImpl implements Logger {
     private readonly logger: winston.Logger;
 
-    constructor(transport: winston.transport) {
+    constructor(transport: winston.transport, logLevel: string = 'info') {
         this.logger = winston.createLogger({
             format: format.combine(format.errors({ stack: true }), format.timestamp(), format.cli()),
-            level: 'info',
+            level: logLevel,
             transports: [
                 transport
             ],

--- a/tests/adapter/Logger.spec.ts
+++ b/tests/adapter/Logger.spec.ts
@@ -1,62 +1,203 @@
 import Transport from 'winston-transport'
 import { LoggerImpl } from "../../src/adapter/LoggerImpl";
 
-class TestStringTransport extends Transport {
-    public lines: string[] = []
+class MockTransport extends Transport {
+    public logs: Array<{ message: string; level: string }> = [];
 
     constructor() {
-        super()
+        super();
     }
 
     reset(): void {
-        this.lines = []
+        this.logs = [];
     }
 
-    log(info: unknown, callback: () => void) {
-        if (typeof info === "string") {
-            this.lines.push(info)
+    log(info: any, callback: () => void) {
+        let message: string;
+
+
+        // Try to get the message from various sources
+        if (info.message && typeof info.message === 'string' && !info.message.includes('[object Object]')) {
+            message = info.message.trim();
         } else {
-            this.lines.push(JSON.stringify(info))
+            // If message is stringified object, try to find the actual object
+            // Exclude winston internal properties
+            const { message: msg, level: lvl, timestamp, symbol, splat, ...rest } = info;
+            // If there are other properties, stringify them
+            if (Object.keys(rest).length > 0) {
+                message = JSON.stringify(rest);
+            } else {
+                message = String(info.message || '');
+            }
         }
 
-        callback()
+        this.logs.push({
+            message,
+            level: String(info.level).trim()
+        });
+        callback();
     }
-};
+}
 
-describe('Logger', () => {
-    // LoggerImpl is intentionally instantiated here because this test suite
-    // is specifically testing the LoggerImpl adapter implementation
-    const loggerOutput = new TestStringTransport()
-    const logger = new LoggerImpl(loggerOutput)
+describe('LoggerImpl', () => {
+    let mockTransport: MockTransport;
+    let logger: LoggerImpl;
 
     beforeEach(() => {
-        loggerOutput.reset();
-    })
+        mockTransport = new MockTransport();
+        logger = new LoggerImpl(mockTransport);
+    });
 
-    it('should write an error message to the log', () => {
-        // when
-        logger.error('error');
+    describe('error', () => {
+        it('should_write_error_message_when_error_is_called', () => {
+            // when
+            logger.error('error message');
 
-        // then
-        expect(JSON.parse(loggerOutput.lines[0]).message.trim()).toEqual("error");
-        expect(JSON.parse(loggerOutput.lines[0]).level.trim()).toContain("error");
-    })
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            expect(mockTransport.logs[0].message).toBe('error message');
+            expect(mockTransport.logs[0].level).toContain('error');
+        });
 
-    it('should write a warning message to the log', () => {
-        // when
-        logger.warning('warning');
+        it('should_handle_object_messages_when_error_is_called', () => {
+            // when
+            const errorObj = { code: 'ERR001', details: 'Something went wrong' };
+            logger.error(errorObj);
 
-        // then
-        expect(JSON.parse(loggerOutput.lines[0]).message.trim()).toEqual("warning");
-        expect(JSON.parse(loggerOutput.lines[0]).level.trim()).toContain("warn");
-    })
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            // Winston will log the object - the exact representation depends on how it serializes
+            expect(mockTransport.logs[0].level).toContain('error');
+        });
 
-    it('should write an info message to the log', () => {
-        // when
-        logger.info('info');
+        it('should_handle_null_message_in_error_logging', () => {
+            // when
+            logger.error(null);
 
-        // then
-        expect(JSON.parse(loggerOutput.lines[0]).message.trim()).toEqual("info");
-        expect(JSON.parse(loggerOutput.lines[0]).level.trim()).toContain("info");
-    })
-})
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            expect(mockTransport.logs[0].message).toBe('null');
+            expect(mockTransport.logs[0].level).toContain('error');
+        });
+    });
+
+    describe('warning', () => {
+        it('should_write_warning_message_when_warning_is_called', () => {
+            // when
+            logger.warning('warning message');
+
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            expect(mockTransport.logs[0].message).toBe('warning message');
+            expect(mockTransport.logs[0].level).toContain('warn');
+        });
+
+        it('should_handle_object_messages_when_warning_is_called', () => {
+            // when
+            const warningObj = { code: 'WARN001', message: 'Be careful' };
+            logger.warning(warningObj);
+
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            // Winston will log the object - the exact representation depends on how it serializes
+            expect(mockTransport.logs[0].level).toContain('warn');
+        });
+    });
+
+    describe('info', () => {
+        it('should_write_info_message_when_info_is_called', () => {
+            // when
+            logger.info('info message');
+
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            expect(mockTransport.logs[0].message).toBe('info message');
+            expect(mockTransport.logs[0].level).toContain('info');
+        });
+
+        it('should_handle_object_messages_when_info_is_called', () => {
+            // when
+            const infoObj = { action: 'sync_started', timestamp: '2024-01-01' };
+            logger.info(infoObj);
+
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            // Winston will log the object - the exact representation depends on how it serializes
+            expect(mockTransport.logs[0].level).toContain('info');
+        });
+    });
+
+    describe('debug', () => {
+        it('should_call_transport_with_debug_level_when_debug_is_called', () => {
+            // given
+            const transportWithDebugLevel = new MockTransport();
+            const loggerWithDebugLevel = new LoggerImpl(transportWithDebugLevel, 'debug');
+
+            // when
+            loggerWithDebugLevel.debug('debug message');
+
+            // then
+            expect(transportWithDebugLevel.logs).toHaveLength(1);
+            expect(transportWithDebugLevel.logs[0].message).toBe('debug message');
+            expect(transportWithDebugLevel.logs[0].level).toContain('verbose');
+        });
+    });
+
+    describe('trace', () => {
+        it('should_call_transport_with_debug_level_when_trace_is_called', () => {
+            // given
+            const transportWithDebugLevel = new MockTransport();
+            const loggerWithDebugLevel = new LoggerImpl(transportWithDebugLevel, 'debug');
+
+            // when
+            loggerWithDebugLevel.trace('trace message');
+
+            // then
+            expect(transportWithDebugLevel.logs).toHaveLength(1);
+            expect(transportWithDebugLevel.logs[0].message).toBe('trace message');
+            expect(transportWithDebugLevel.logs[0].level).toContain('debug');
+        });
+    });
+
+    describe('multiple messages', () => {
+        it('should_log_multiple_messages_in_sequence', () => {
+            // when
+            logger.info('first');
+            logger.warning('second');
+            logger.error('third');
+
+            // then
+            expect(mockTransport.logs).toHaveLength(3);
+            expect(mockTransport.logs[0].message).toBe('first');
+            expect(mockTransport.logs[0].level).toContain('info');
+            expect(mockTransport.logs[1].message).toBe('second');
+            expect(mockTransport.logs[1].level).toContain('warn');
+            expect(mockTransport.logs[2].message).toBe('third');
+            expect(mockTransport.logs[2].level).toContain('error');
+        });
+    });
+
+    describe('with custom log level', () => {
+        it('should_respect_custom_log_level_parameter', () => {
+            // given
+            const transportWithDebugLevel = new MockTransport();
+
+            // when
+            const loggerWithDebugLevel = new LoggerImpl(transportWithDebugLevel, 'debug');
+            loggerWithDebugLevel.debug('debug message');
+
+            // then
+            expect(transportWithDebugLevel.logs).toHaveLength(1);
+            expect(transportWithDebugLevel.logs[0].level).toContain('verbose');
+        });
+
+        it('should_use_default_info_level_when_not_specified', () => {
+            // when
+            logger.info('info message');
+
+            // then
+            expect(mockTransport.logs).toHaveLength(1);
+            expect(mockTransport.logs[0].level).toContain('info');
+        });
+    });
+});

--- a/tests/adapter/LoggerImpl.infra.spec.ts
+++ b/tests/adapter/LoggerImpl.infra.spec.ts
@@ -1,0 +1,149 @@
+import Transport from 'winston-transport';
+import { LoggerImpl } from '../../src/adapter/LoggerImpl';
+
+class CaptureTransport extends Transport {
+    public capturedLogs: Array<{ message: string; level: string; timestamp: string }> = [];
+
+    constructor() {
+        super();
+    }
+
+    reset(): void {
+        this.capturedLogs = [];
+    }
+
+    log(info: any, callback: () => void) {
+        this.capturedLogs.push({
+            message: String(info.message || '').trim(),
+            level: String(info.level || '').trim(),
+            timestamp: String(info.timestamp || '')
+        });
+        callback();
+    }
+}
+
+describe('LoggerImpl.InfraTest', () => {
+    let captureTransport: CaptureTransport;
+    let logger: LoggerImpl;
+
+    beforeEach(() => {
+        captureTransport = new CaptureTransport();
+        logger = new LoggerImpl(captureTransport);
+    });
+
+    describe('logging with Winston transport', () => {
+        it('should_write_to_transport_when_error_is_called', () => {
+            // when
+            logger.error('test error');
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].message).toBe('test error');
+            expect(captureTransport.capturedLogs[0].level).toContain('error');
+        });
+
+        it('should_write_to_transport_when_warning_is_called', () => {
+            // when
+            logger.warning('test warning');
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].message).toBe('test warning');
+            expect(captureTransport.capturedLogs[0].level).toContain('warn');
+        });
+
+        it('should_write_to_transport_when_info_is_called', () => {
+            // when
+            logger.info('test info');
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].message).toBe('test info');
+            expect(captureTransport.capturedLogs[0].level).toContain('info');
+        });
+
+        it('should_respect_log_level_filter_when_debug_level_not_enabled', () => {
+            // given - logger initialized with default 'info' level
+            const infoTransport = new CaptureTransport();
+            const infoLevelLogger = new LoggerImpl(infoTransport, 'info');
+
+            // when
+            infoLevelLogger.debug('test debug');
+
+            // then - debug message should not be captured because level is 'info'
+            expect(infoTransport.capturedLogs).toHaveLength(0);
+        });
+
+        it('should_capture_debug_message_when_debug_level_enabled', () => {
+            // given - logger initialized with 'debug' level
+            const debugTransport = new CaptureTransport();
+            const debugLevelLogger = new LoggerImpl(debugTransport, 'debug');
+
+            // when
+            debugLevelLogger.debug('test debug');
+
+            // then
+            expect(debugTransport.capturedLogs).toHaveLength(1);
+            expect(debugTransport.capturedLogs[0].message).toBe('test debug');
+            expect(debugTransport.capturedLogs[0].level).toContain('verbose');
+        });
+
+        it('should_include_timestamp_in_log_entry', () => {
+            // when
+            logger.info('test message');
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].timestamp).toBeDefined();
+            expect(captureTransport.capturedLogs[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        });
+
+        it('should_handle_object_message_with_transport', () => {
+            // when
+            const errorObj = { code: 'ERR_001', message: 'Something failed' };
+            logger.error(errorObj);
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].level).toContain('error');
+            // Object is serialized by Winston
+            expect(captureTransport.capturedLogs[0].message).toBeDefined();
+        });
+
+        it('should_handle_null_message_with_transport', () => {
+            // when
+            logger.error(null);
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].level).toContain('error');
+            expect(captureTransport.capturedLogs[0].message).toBe('null');
+        });
+
+        it('should_handle_error_objects_with_stack_traces', () => {
+            // when
+            const error = new Error('Test error');
+            logger.error(error);
+
+            // then
+            expect(captureTransport.capturedLogs).toHaveLength(1);
+            expect(captureTransport.capturedLogs[0].level).toContain('error');
+            // Error object is captured by transport
+            expect(captureTransport.capturedLogs[0].message).toBeDefined();
+        });
+
+        it('should_use_provided_transport_for_logging', () => {
+            // given
+            const customTransport = new CaptureTransport();
+            const customLogger = new LoggerImpl(customTransport);
+
+            // when
+            customLogger.info('test');
+
+            // then - message should be in the custom transport, not the original one
+            expect(customTransport.capturedLogs).toHaveLength(1);
+            expect(customTransport.capturedLogs[0].message).toBe('test');
+        });
+    });
+});
+


### PR DESCRIPTION
Make the log level configurable and add tests for `LoggerImpl` to make sure that logging works as expected.
