### PR TITLE
test: clean up listeners after each test

### DIFF
--- a/tests/adapter/LoggerImpl.infra.spec.ts
+++ b/tests/adapter/LoggerImpl.infra.spec.ts
@@ -31,6 +31,7 @@ describe('LoggerImpl.InfraTest', () => {
         logger = new LoggerImpl(captureTransport);
     });
 
+
     describe('logging with Winston transport', () => {
         it('should_write_to_transport_when_error_is_called', () => {
             // when

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,1 +1,24 @@
 import 'reflect-metadata';
+
+// snapshot the initial process-level listeners so we don't remove Jest's own handlers
+const baselineUncaughtExceptionListeners = process.listeners('uncaughtException');
+const baselineUnhandledRejectionListeners = process.listeners('unhandledRejection');
+
+// Clean up Winston logger (and other test-added) listeners after each test to prevent memory leak warnings
+afterEach(() => {
+    // Remove uncaughtException listeners that were not present at startup
+    process.listeners('uncaughtException').forEach(listener => {
+        if (!baselineUncaughtExceptionListeners.includes(listener)) {
+            process.off('uncaughtException', listener);
+        }
+    });
+
+    // Remove unhandledRejection listeners that were not present at startup
+    process.listeners('unhandledRejection').forEach(listener => {
+        if (!baselineUnhandledRejectionListeners.includes(listener)) {
+            process.off('unhandledRejection', listener);
+        }
+    });
+});
+
+


### PR DESCRIPTION
# Problem
The test suite was generating `MaxListenersExceededWarning` warnings when running multiple tests. The warning indicated that more than 10 `uncaughtException` and `unhandledRejection` listeners were being added to the Node.js process event emitter, which triggered Node's memory leak detection.

# Root Cause
Winston logger instances created during tests register event handlers on the process for exception and rejection handling through the `exceptionHandlers` and `rejectionHandlers` configuration. When multiple test files instantiate `LoggerImpl` (which wraps Winston), these listeners accumulate on the global process object. Since Jest runs tests in a single process, the listener count exceeded the default threshold of 10.